### PR TITLE
Minor grammar fix

### DIFF
--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -1,5 +1,5 @@
 {
-    "cpu_usage": "CPU auslastung",
-    "ram_usage": "RAM auslastung",
+    "cpu_usage": "CPU Auslastung",
+    "ram_usage": "RAM Auslastung",
     "usage": "Verbrauch"
 }


### PR DESCRIPTION
"Auslastung" (usage) is a noun in German. So it's spelled with a capital A.